### PR TITLE
Changes/Enhancements from issues 5&6

### DIFF
--- a/Mutex/Mutex.psd1
+++ b/Mutex/Mutex.psd1
@@ -34,6 +34,7 @@
         'New-Mutex'
         'Remove-Mutex'
         'Set-MutexDefault'
+        'Test-Mutex'
         'Unlock-Mutex'
     )
 

--- a/Mutex/functions/Lock-Mutex.ps1
+++ b/Mutex/functions/Lock-Mutex.ps1
@@ -2,17 +2,19 @@
     <#
     .SYNOPSIS
         Acquire a lock on a mutex.
-    
+
     .DESCRIPTION
         Acquire a lock on a mutex.
         Implicitly calls New-Mutex if the mutex hasn't been taken under the management of the current process yet.
-    
+
     .PARAMETER Name
-        Name of the mutex to acquire a lock on.
-    
+        Name of the mutex to acquire a lock on. If the mutex should be globally valid on a multi user system
+        prefix the name with "Global\". Otherwise it is assumed that it belongs only to the current
+        user session (equals the prefix "Local\").
+
     .PARAMETER Timeout
         How long to wait for acquiring the mutex, before giving up with an error.
-    
+
     .EXAMPLE
         PS C:\> Lock-Mutex -Name MyModule.LogFile
 
@@ -40,7 +42,6 @@
                 }
             }
             $script:mutexes[$mutexName].Status = 'Locked'
-            $script:mutexes[$mutexName].LockCount++
         }
     }
 }

--- a/Mutex/functions/Lock-Mutex.ps1
+++ b/Mutex/functions/Lock-Mutex.ps1
@@ -42,6 +42,7 @@
                 }
             }
             $script:mutexes[$mutexName].Status = 'Locked'
+            $script:mutexes[$mutexName].LockCount++
         }
     }
 }

--- a/Mutex/functions/New-Mutex.ps1
+++ b/Mutex/functions/New-Mutex.ps1
@@ -108,6 +108,7 @@
             Name      = $newName
             Status    = "Open"
             Object    = $mutex
+            LockCount = 0
         }
     }
 }

--- a/Mutex/functions/New-Mutex.ps1
+++ b/Mutex/functions/New-Mutex.ps1
@@ -2,18 +2,21 @@
     <#
     .SYNOPSIS
         Create a new mutex managed by this module.
-    
+
     .DESCRIPTION
         Create a new mutex managed by this module.
         The mutex is created in an unacquired state.
         Use Lock-Mutex to acquire the mutex.
 
         Note: Calling Lock-Mutex without first calling New-Mutex will implicitly call New-Mutex.
-        
+
     .PARAMETER Name
         Name of the mutex to create.
         The name is what the system selects for when marshalling access:
-        All mutexes with the same name block each other, across all processes on the current host.
+        All mutexes with the same name block each other, across all processes on the current host/user.
+        If the mutex should be globally valid on a multi user system
+        prefix the name with "Global\". Otherwise it is assumed that it belongs only to the current
+        user session (equals the prefix "Local\").
 
     .PARAMETER Access
         Which set of permissions to apply to the mutex.
@@ -28,10 +31,10 @@
         Create the mutex with the specified name casing.
         By default, mutexes managed by this module are lowercased to guarantee case-insensitivity across all PowerShell executions.
         This however would potentially affect interoperability with other tools & languages, hence this parameter to enable casing fidelity at the cost of case sensitivity.
-        
+
         Note: Even when enabling this, only one instance of name (compared WITHOUT case sensitivity) can be stored within this module!
         For example, the mutexes "Example" and "eXample" could not coexist within the Mutex PowerShell module, even though they are distinct from each other and even when using the -CaseSpecific parameter.
-    
+
     .EXAMPLE
         PS C:\> New-Mutex -Name MyModule.LogFile
 
@@ -56,7 +59,7 @@
         [switch]
         $CaseSpecific
     )
-	
+
     process {
         $newName = $Name.ToLower()
         if ($CaseSpecific) { $newName = $Name }
@@ -105,7 +108,6 @@
             Name      = $newName
             Status    = "Open"
             Object    = $mutex
-            LockCount = 0
         }
     }
 }

--- a/Mutex/functions/Test-Mutex.ps1
+++ b/Mutex/functions/Test-Mutex.ps1
@@ -34,20 +34,19 @@
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [string]
         $Name,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
         [switch]
         $CheckIfLocked
     )
 
     process {
             $existingMutex = $null
-            if ([System.Threading.Mutex]::TryOpenExisting($Name, [ref]$existingMutex) -eq $false) {
+            if (-not [System.Threading.Mutex]::TryOpenExisting($Name, [ref]$existingMutex)) {
                 return $false
             }
             if ($CheckIfLocked) {
                 $canItBeLocked = $existingMutex.WaitOne(5)
                 if ($canItBeLocked) { $existingMutex.ReleaseMutex() }
-                return ($canItBeLocked -eq $false)
+                return (-not $canItBeLocked)
             }
             return $true
     }

--- a/Mutex/functions/Test-Mutex.ps1
+++ b/Mutex/functions/Test-Mutex.ps1
@@ -1,0 +1,46 @@
+﻿function Test-Mutex {
+    <#
+    .SYNOPSIS
+        Check if a mutex has been already used in another process.
+
+        .DESCRIPTION
+        Check if a mutex has been already used in another process.
+        This method can only check if a mutex by agiven name has been initialized in another process.
+        It does not check if the mutex is currently been locked.
+
+    .PARAMETER Name
+        Name of the mutex to acquire a lock on. If the mutex should be globally valid on a multi user system
+        prefix the name with "Global\". Otherwise it is assumed that it belongs only to the current
+        user session (equals the prefix "Local\").
+
+    .EXAMPLE
+        PS C:\> Test-Mutex -Name MyModule.LogFile
+
+        Checks if the mutex 'MyModule.LogFile' has been created in another process.
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $Name
+    )
+
+    process {
+        $result = $false
+        if ($script:mutexes[$Name]) {
+            $result = $true
+        }
+        else {
+            $placeHolder = $null
+            try {
+                if ([System.Threading.Mutex]::TryOpenExisting($Name, [ref]$placeHolder) -eq $true) {
+                    $result = $true
+                }
+            }
+            catch {
+                Write-Error $_
+            }
+        }
+        $result
+    }
+}

--- a/Mutex/functions/Test-Mutex.ps1
+++ b/Mutex/functions/Test-Mutex.ps1
@@ -3,7 +3,7 @@
     .SYNOPSIS
         Check if a mutex has been already used in another process.
 
-        .DESCRIPTION
+    .DESCRIPTION
         Check if a mutex has been already used in another process.
         This method can only check if a mutex by agiven name has been initialized in another process.
         It does not check if the mutex is currently been locked.
@@ -13,34 +13,42 @@
         prefix the name with "Global\". Otherwise it is assumed that it belongs only to the current
         user session (equals the prefix "Local\").
 
+    .PARAMETER CheckIfLocked
+        If used Test-Mutex will also check if an existing Mutex has been already locked.
+
     .EXAMPLE
         PS C:\> Test-Mutex -Name MyModule.LogFile
 
         Checks if the mutex 'MyModule.LogFile' has been created in another process.
+
+    .EXAMPLE
+        PS C:\> Test-Mutex -Name MyModule.LogFile -CheckIfLocked
+
+        Checks if the mutex 'MyModule.LogFile' has been created in another process and if it's locked.
+        Returns $false if it does not exist or if it's currently not locked.
+        Therefor: $false means you can use it/the corresponding ressource.
     #>
     [CmdletBinding()]
+    [OutputType([bool])]
     Param (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [string]
-        $Name
+        $Name,
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
+        [switch]
+        $CheckIfLocked
     )
 
     process {
-        $result = $false
-        if ($script:mutexes[$Name]) {
-            $result = $true
-        }
-        else {
-            $placeHolder = $null
-            try {
-                if ([System.Threading.Mutex]::TryOpenExisting($Name, [ref]$placeHolder) -eq $true) {
-                    $result = $true
-                }
+            $existingMutex = $null
+            if ([System.Threading.Mutex]::TryOpenExisting($Name, [ref]$existingMutex) -eq $false) {
+                return $false
             }
-            catch {
-                Write-Error $_
+            if ($CheckIfLocked) {
+                $canItBeLocked = $existingMutex.WaitOne(5)
+                if ($canItBeLocked) { $existingMutex.ReleaseMutex() }
+                return ($canItBeLocked -eq $false)
             }
-        }
-        $result
+            return $true
     }
 }

--- a/Mutex/functions/Unlock-Mutex.ps1
+++ b/Mutex/functions/Unlock-Mutex.ps1
@@ -38,7 +38,6 @@
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [string]
         $Name,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
         [switch]
         $Force
     )

--- a/Mutex/functions/Unlock-Mutex.ps1
+++ b/Mutex/functions/Unlock-Mutex.ps1
@@ -10,10 +10,6 @@
     .PARAMETER Name
         The name of the mutex to release the lock on.
 
-    .PARAMETER UnlockOnlyOnce
-        If the mutex has been locked multiple times using this parameter only unlocks it once.
-        The LockCount of a mutex can be viewed by Get-Mutex
-
     .EXAMPLE
         PS C:\> Unlock-Mutex -Name MyModule.LogFile
 
@@ -28,9 +24,7 @@
     Param (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [string]
-        $Name,
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
-        [switch]$UnlockOnlyOnce
+        $Name
     )
 
     process {
@@ -40,16 +34,17 @@
 
             if ($mutex.Status -eq "Open" -and $mutex.LockCount -le 0) { return }
             if ($UnlockOnlyOnce) { $unLockCycleCount = 1 }else { $unLockCycleCount = $mutex.LockCount }
-            for ($iteration = 0; $iteration -lt $unLockCycleCount; $iteration++) {
-                try {
+            try {
+                # Repeat Releasing until MethodInvocationException is thrown
+                while ($true) {
                     $mutex.Object.ReleaseMutex()
-                    $mutex.LockCount--
                 }
-                catch { $PSCmdlet.WriteError($_) }
             }
-
-            if ($mutex.LockCount -le 0) {
+            catch [System.Management.Automation.MethodInvocationException] {
                 $mutex.Status = 'Open'
+            }
+            catch {
+                catch { $PSCmdlet.WriteError($_) }
             }
         }
     }


### PR DESCRIPTION
-Added Test-Mutex for checking if a mutex has been declared in another process (First part of issue 5)
-Added hint of using "Global\" naming prefix to parameter help
-Removed LockCount (Issue 6)
-Unlock-Mutex will try releasing the Mutex until an exception is thrown (Issue 6)